### PR TITLE
Replace hardcoded Gemini calls with LiteLLM for broader LLM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,14 @@ Create a `.env` file in the root directory of the project with the following for
 
 ```nano .env```
 
-```LLM_API_KEY= YOUR_LLM_API_KEY_HERE```
+```LLM_API_KEY= YOUR_LLM_API_KEY_HERE``` (Deprecated: Use provider-specific keys below)
+
+For LiteLLM to work with your specific provider, set the appropriate environment variable:
+
+- **Google Gemini**: `GOOGLE_API_KEY=your_key`
+- **OpenAI**: `OPENAI_API_KEY=your_key`
+- **Anthropic**: `ANTHROPIC_API_KEY=your_key`
+- etc.
 
 ```NCBI_API_KEY= YOUR_NCBI_API_KEY_HERE```
 

--- a/generate_lists/llm_mine_gene_pathway_assoc_oncotree.py
+++ b/generate_lists/llm_mine_gene_pathway_assoc_oncotree.py
@@ -15,14 +15,10 @@ from pydantic import BaseModel, ConfigDict, Field
 
 load_dotenv()
 
-if "USE_LITELLM_PROXY" not in os.environ:
-    YOUR_API_KEY = os.getenv("LLM_API_KEY")
+# if "USE_LITELLM_PROXY" not in os.environ:
+#     YOUR_API_KEY = os.getenv("LLM_API_KEY")
+#     os.environ["GOOGLE_API_KEY"] = YOUR_API_KEY
 
-    # Set API keys for providers
-    # os.environ["OPENAI_API_KEY"] = YOUR_API_KEY
-    # os.environ["ANTHROPIC_API_KEY"] = YOUR_API_KEY
-    os.environ["GOOGLE_API_KEY"] = YOUR_API_KEY
-    # os.environ["MISTRAL_API_KEY"] = YOUR_API_KEY
 
 
 class AssociatedPathways(BaseModel):

--- a/generate_lists/validate_genelist.py
+++ b/generate_lists/validate_genelist.py
@@ -20,13 +20,9 @@ NCBI_API_KEY = os.getenv("NCBI_API_KEY")
 # DEBUG = os.getenv("DEBUG", "").strip().lower() in ("true", "1", "yes", "y", "on")
 DEBUG = True
 
-if "USE_LITELLM_PROXY" not in os.environ:
-    YOUR_API_KEY = os.getenv("LLM_API_KEY")
-    # Set API keys for providers
-    # os.environ["OPENAI_API_KEY"] = YOUR_API_KEY
-    # os.environ["ANTHROPIC_API_KEY"] = YOUR_API_KEY
-    os.environ["GOOGLE_API_KEY"] = YOUR_API_KEY
-    # os.environ["MISTRAL_API_KEY"] = YOUR_API_KEY
+# if "USE_LITELLM_PROXY" not in os.environ:
+#     YOUR_API_KEY = os.getenv("LLM_API_KEY")
+#     os.environ["GOOGLE_API_KEY"] = YOUR_API_KEY
 
 
 class Answer(BaseModel):

--- a/run_scripts/run_llm_generate_lists.sh
+++ b/run_scripts/run_llm_generate_lists.sh
@@ -14,7 +14,7 @@ ONCOTREE_TRY2="BRCA"
 python generate_lists/llm_mine_gene_pathway_assoc_oncotree.py \
     -i "$INPUT_FILE" \
     -o "$OUTPUT_FILE"\
-    -model "$MODEL_NAME" \
+    -model "$MODEL_NAME" \ # Supports any model: e.g. gpt-4o, claude-3-5-sonnet, gemini/gemini-pro
     -temp "$TEMPERATURE" \
     -c "$ONCOTREE_TRY1" \
     -c "$ONCOTREE_TRY2"


### PR DESCRIPTION
Resolves #12 

This pull request removes the hardcoded dependency on GOOGLE_API_KEY, enabling full support for any LLM provider via LiteLLM (e.g., OpenAI, Anthropic, Vertex AI).

Changes:
- Removed logic that forcibly mapped LLM_API_KEY to GOOGLE_API_KEY in llm_mine_gene_pathway_assoc_oncotree.py and validate_genelist.py .
- Updated README.md to instruct users to set provider-specific environment variables (e.g., OPENAI_API_KEY, ANTHROPIC_API_KEY) instead of a generic key.
- Updated run_llm_generate_lists.sh comments to reflect that any LiteLLM-supported model can now be used.

Verification:
- Validated that scripts still initialize correctly with --help.
- Confirmed that the litellm library now handles API key resolution via standard environment variables.